### PR TITLE
Fix: add grunt env config to circle config

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -45,7 +45,7 @@ deployment:
   develop:
     branch: develop
     commands:
-      - grunt build
+      - grunt build --env=stage
       - docker build -t $REPO:$TAG .
       - docker push $REPO:$TAG
       - eb deploy


### PR DESCRIPTION
This will ensure the correct server urls are used for the "stage" environment (thisissoon.elasticbeanstalk.com). Without the flag it will default to "production" (thisissoon.com).