### PR TITLE
Fix: disable skrollr on sm/xs viewport sizes

### DIFF
--- a/app/js/thisissoon-core/app.js
+++ b/app/js/thisissoon-core/app.js
@@ -28,6 +28,7 @@ angular.module("thisissoon.core", [
 
 .run([
     "$rootScope",
+    "$window",
     "CacheService",
     "snSkrollr",
     "ENV",
@@ -36,9 +37,11 @@ angular.module("thisissoon.core", [
      * @param {Service} $rootScope
      * @param {Service} CacheService
      */
-    function ($rootScope, CacheService, snSkrollr, ENV) {
+    function ($rootScope, $window, CacheService, snSkrollr, ENV) {
 
-        snSkrollr.init();
+        if ($window.innerWidth > 1023) {
+            snSkrollr.init();
+        }
 
         $rootScope.cache = CacheService;
         $rootScope.env = ENV;

--- a/app/js/thisissoon-core/app.js
+++ b/app/js/thisissoon-core/app.js
@@ -28,6 +28,7 @@ angular.module("thisissoon.core", [
 
 .run([
     "$rootScope",
+    "ResizeService",
     "$window",
     "CacheService",
     "snSkrollr",
@@ -37,11 +38,17 @@ angular.module("thisissoon.core", [
      * @param {Service} $rootScope
      * @param {Service} CacheService
      */
-    function ($rootScope, $window, CacheService, snSkrollr, ENV) {
+    function ($rootScope, ResizeService, $window, CacheService, snSkrollr, ENV) {
 
-        if ($window.innerWidth > 1023) {
-            snSkrollr.init();
-        }
+        ResizeService.add($rootScope.$id, function(event, size) {
+            if (size.width >= 1024 && !$rootScope.skrollrInitialised) {
+                snSkrollr.init();
+                $rootScope.skrollrInitialised = true;
+            } else if (size.width < 1024 && $rootScope.skrollrInitialised) {
+                $rootScope.skrollrInitialised = false;
+                snSkrollr.destroy();
+            }
+        });
 
         $rootScope.cache = CacheService;
         $rootScope.env = ENV;
@@ -59,6 +66,9 @@ angular.module("thisissoon.core", [
         // close nav menu when changing views
         $rootScope.$on("$routeChangeSuccess", function() {
             CacheService.put("loading", false);
+            if ($rootScope.skrollrInitialised) {
+                snSkrollr.refresh();
+            }
         });
 
     }

--- a/app/js/thisissoon-core/config.js
+++ b/app/js/thisissoon-core/config.js
@@ -15,12 +15,11 @@ angular.module("thisissoon.core").config([
      */
     function ($routeProvider, $httpProvider, snSkrollrProvider) {
 
-        snSkrollrProvider.init = {
+        snSkrollrProvider.config = {
             forceHeight: false,
             smoothScrolling: true,
             mobileDeceleration: 0.004
         };
-
 
         $httpProvider.defaults.cache = false;
 

--- a/app/less/default/modules/navbar.less
+++ b/app/less/default/modules/navbar.less
@@ -22,14 +22,17 @@ nav.navbar {
         position: relative;
     }
 
+    a {
+        display: block;
+        height: 100%;
+        padding: 30px 29px 11px 5px;
+        .transition(~"background 0.2s, color 0.2s");
+    }
+
     a:link,
     a:visited,
     a:focus {
         background-color: transparent;
-        display: block;
-        height: 100%;
-        .transition(~"background 0.2s, color 0.2s");
-        padding: 30px 29px 11px 5px;
     }
 
     a:hover,
@@ -84,6 +87,10 @@ nav.navbar {
 .navbar-fixed-top {
     left: inherit;
     right: inherit;
+
+    .navbar-collapse {
+        max-height: none;
+    }
 }
 
 .navbar-hide {

--- a/app/less/mobile/modules/navbar.less
+++ b/app/less/mobile/modules/navbar.less
@@ -16,6 +16,7 @@ nav.navbar {
 
     li a {
         .h2;
+        font-size: 2.2em;
         margin: 0;
         padding: 10px 20px;
     }

--- a/app/less/tablet/modules/navbar.less
+++ b/app/less/tablet/modules/navbar.less
@@ -17,7 +17,7 @@ nav.navbar {
     li a {
         .h2;
         margin: 0;
-        padding: 10px 40px;
+        padding: 6px 40px;
     }
 
     .nav-open & {

--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,7 @@
     "velocity": "1.2.1",
     "angular-scroll": "0.6.4",
     "angular-velocity-animate": "~0.0.1",
-    "angular-skrollr": "~0.0.1",
+    "angular-skrollr": "~0.0.3",
     "skrollr": "~0.6.29"
   },
   "devDependencies": {


### PR DESCRIPTION
Skrollr causes some issues on mobile. It is recommended to use `id=skrollr-body` on the scrollable element, skrollr then disabled native scrolling and uses css transforms. However as our menu and projects overlay are `position: fixed` this causes issues. The `position: fixed` elements can be set outside the `skrollr-body` however they are still not scrollable, as skrollr disables native scrolling on mobile (in favour of a css transforms method).

As we aren't actually using skrollr on mobile/tablet at the moment anyway (atm it is used only for the soon logo in desktop view) I have disabled skrollr initialisation if the viewport is smaller than 1024.