### PR TITLE
Feature: only display results heading if stats available

### DIFF
--- a/app/partials/project-stats.html
+++ b/app/partials/project-stats.html
@@ -1,10 +1,10 @@
-<div class="content container-fluid">
+<div class="content container-fluid" ng-if="project.project_stats.length || project.quote || project.link">
     <div class="row">
-        <div class="col-lg-8  col-lg-offset-4  col-md-8  col-md-offset-4  col-sm-12  col-sm-offset-0  col-xs-12  col-xs-offset-0">
+        <div class="col-lg-8  col-lg-offset-4  col-md-8  col-md-offset-4  col-sm-12  col-sm-offset-0  col-xs-12  col-xs-offset-0" ng-if="project.project_stats.length">
             <h1>Results</h1>
         </div>
         <div class="col-lg-8  col-lg-offset-4  col-md-8  col-md-offset-4  col-sm-12  col-sm-offset-0  col-xs-12  col-xs-offset-0">
-            <div class="row padding-full">
+            <div class="row padding-full" ng-if="project.project_stats.length">
                 <div class="col-lg-6 col-md-6 col-sm-6 col-xs-6" ng-repeat="stat in project.project_stats">
                     <div class="stats" >
                         <p><span class="h1">{{ stat.value }}</span> {{ stat.stat.title }}</p>
@@ -12,8 +12,8 @@
                 </div>
             </div>
             <div>
-                <h3 class="quote">&ldquo;{{ project.quote }}&rdquo;</h3>
-                <p class="padding-bottom">{{ project.quote_attribution }}</p>
+                <h3 class="quote" ng-if="project.quote">&ldquo;{{ project.quote }}&rdquo;</h3>
+                <p class="padding-bottom" ng-if="project.quote">{{ project.quote_attribution }}</p>
                 <h3 ng-if="project.link"><a ng-href="{{ project.link }}" target="_blank">Visit {{ project.linkText }}</a></h3>
             </div>
         </div>


### PR DESCRIPTION
This PR adds conditional display of element in results section:
 - only display "results" heading, if stats are available
 - only display quote/quote-attribution if available
 - hide entire section if neither stats, quote or link is available