### PR TITLE
Feature: improved method for filtering 'http://' and 'www.' from link text

### DIFF
--- a/app/js/thisissoon-core/filters/linkDisplay.js
+++ b/app/js/thisissoon-core/filters/linkDisplay.js
@@ -9,7 +9,7 @@ angular.module("thisissoon.core").filter("linkDisplay", [
     "$filter",
     function($filter) {
         return function(input) {
-            return input.split("/")[2].split("www.")[1];
+            return input.replace("http://", "").replace("www.", "");
         };
     }
 ])

--- a/tests/unit/thisissoon-core/filters/linkDisplay.js
+++ b/tests/unit/thisissoon-core/filters/linkDisplay.js
@@ -14,8 +14,18 @@ describe("linkDisplay", function() {
 
     }));
 
-    it("should return link without 'http://www'", function(){
+    it("should return link without 'http://www.'", function(){
         var result = filter("http://www.thisissoon.com");
+        expect(result).toEqual("thisissoon.com");
+    });
+
+    it("should return link without 'http://'", function(){
+        var result = filter("http://thisissoon.com");
+        expect(result).toEqual("thisissoon.com");
+    });
+
+    it("should return link without 'www.'", function(){
+        var result = filter("www.thisissoon.com");
         expect(result).toEqual("thisissoon.com");
     });
 


### PR DESCRIPTION
The previous method did not return the expected result if the link did not contain "http://" and "www.". This improved method works in either cases. I've added test cases to confirm these scenarios.