### PR TITLE
Fix: use vendor-prefix mixins for css transforms

### DIFF
--- a/app/less/default/core/utilities.less
+++ b/app/less/default/core/utilities.less
@@ -29,8 +29,8 @@
     margin-top: 100%;
     padding-right: 40px;
     text-align: right;
-    transform: rotate(-90deg);
-    transform-origin: left top 0;
+    .rotate(-90deg);
+    .transform-origin(left top 0);
 }
 
 .columns-2 {

--- a/app/less/default/modules/nav-counter.less
+++ b/app/less/default/modules/nav-counter.less
@@ -39,8 +39,8 @@
 
     .count-text {
         color: @white;
-        transform: rotate(-90deg);
-        transform-origin: top left;
+        .rotate(-90deg);
+        .transform-origin(top left);
         margin-left: 8px;
         width: 200px;
     }

--- a/app/less/default/modules/project-list.less
+++ b/app/less/default/modules/project-list.less
@@ -40,7 +40,7 @@
         .vertical-center {
             position: absolute;
             top: 50%;
-            transform: translateY(-50%);
+            .translate(0, -50%);
         }
 
         &:hover {
@@ -78,7 +78,7 @@
         left: 100%;
         position: absolute;
         top: 50%;
-        transform: translateY(-50%);
+        .translate(0, -50%);
     }
 }
 

--- a/app/less/mobile/modules/project-list.less
+++ b/app/less/mobile/modules/project-list.less
@@ -18,7 +18,7 @@
         .vertical-center {
             position: relative;
             top: 0;
-            transform: translateY(0);
+            .translate(0, 0);
         }
 
         &:hover {

--- a/app/less/tablet/modules/project-list.less
+++ b/app/less/tablet/modules/project-list.less
@@ -18,7 +18,7 @@
         .vertical-center {
             position: relative;
             top: 0;
-            transform: translateY(0);
+            .translate(0, 0);
         }
 
         &:hover {


### PR DESCRIPTION
This PR prefixes all css transforms using the bootstrap less vendor-prefix mixins. Notably this adds support for safari and iOS.