### PR TITLE
Fix: responsive layout fixes to jobs and project stats

### DIFF
--- a/app/less/default/core/utilities.less
+++ b/app/less/default/core/utilities.less
@@ -38,3 +38,7 @@
     -moz-column-count: 2;
     column-count: 2;
 }
+
+.no-overflow {
+    overflow: hidden;
+}

--- a/app/partials/home-join.html
+++ b/app/partials/home-join.html
@@ -14,13 +14,15 @@
         <div class="col-lg-12 col-lg-offset-4 col-md-12 col-md-offset-4 col-sm-12 col-sm-offset-0 col-xs-12 col-xs-offset-0">
             <div class="row">
                 <div
-                   ng-class="{ 'col-lg-2 col-md-2 col-sm-3 col-xs-6': jobs.length > 2, 'col-lg-4 col-md-4 col-sm-6 col-xs-6': jobs.length <= 2 }"
-                   ng-repeat="job in jobs"
+                    class="no-overflow"
+                    ng-class="{ 'col-lg-2 col-md-2 col-sm-3 col-xs-12': jobs.length > 2, 'col-lg-4 col-md-4 col-sm-6 col-xs-12': jobs.length <= 2 }"
+                    ng-repeat="job in jobs"
                 >
                     <h6>{{ job.title }}</h6>
                     <hr>
                     <p>
                         {{ job.blurb }}
+                        <br>
                         <a ng-href="{{ job.pdf }}" target="_blank" ng-if="job.pdf">View details</a>
                         <a ng-href="mailto:{{ job.email }}" ng-if="job.email">{{ job.email }}</a>
                     </p>

--- a/app/partials/project-stats.html
+++ b/app/partials/project-stats.html
@@ -5,9 +5,13 @@
         </div>
         <div class="col-lg-8  col-lg-offset-4  col-md-8  col-md-offset-4  col-sm-12  col-sm-offset-0  col-xs-12  col-xs-offset-0">
             <div class="row padding-full" ng-if="project.project_stats.length">
-                <div class="col-lg-6 col-md-6 col-sm-6 col-xs-6" ng-repeat="stat in project.project_stats">
+                <div class="col-lg-6 col-md-6 col-sm-6 col-xs-12" ng-repeat="stat in project.project_stats">
                     <div class="stats" >
-                        <p><span class="h1">{{ stat.value }}</span> {{ stat.stat.title }}</p>
+                        <p>
+                            <span class="h1">{{ stat.value }}</span>
+                            <span class="hidden-lg hidden-sm"><br>{{ stat.stat.title }}</span>
+                            <span class="hidden-md hidden-xs">{{ stat.stat.title }}</span>
+                        </p>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Stack jobs and project stats at mobile size. Force "View details" link onto new line in jobs.