### PR TITLE
Fix: removal of project list hover state on mobile

### DIFF
--- a/app/less/mobile/modules/project-list.less
+++ b/app/less/mobile/modules/project-list.less
@@ -23,12 +23,10 @@
 
         &:hover {
             .project-hero {
-                left: -5%;
-            }
-            .view-project {
-                left: 100%;
+                .scale(1);
             }
         }
+
     }
 
 }

--- a/app/less/tablet/modules/project-list.less
+++ b/app/less/tablet/modules/project-list.less
@@ -23,10 +23,7 @@
 
         &:hover {
             .project-hero {
-                left: -5%;
-            }
-            .view-project {
-                left: 100%;
+                .scale(1);
             }
         }
 


### PR DESCRIPTION
This hadn't been updated to disable the new hover state transition, this ensures there is not scaling on hover on mobile.