### PR TITLE
Fix: project list overflow

### DIFF
--- a/app/less/default/modules/project-list.less
+++ b/app/less/default/modules/project-list.less
@@ -17,7 +17,9 @@
         bottom: 0;
         left: 0;
         margin: 0;
-        overflow: auto;
+        overflow-y: scroll;
+        overflow-x: hidden;
+        -webkit-overflow-scrolling: touch;
         padding: 0;
         position: fixed;
         right: 0;


### PR DESCRIPTION
The header position refactoring in #46 had caused overflow-x to be scrollable in the project list. This ensures it is not.

This also adds momentum scrolling on iOS, which is not default within a scrollable div.